### PR TITLE
Fix missing client directive for interactive components

### DIFF
--- a/src/components/CityCombobox.tsx
+++ b/src/components/CityCombobox.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import * as React from "react";
 import { Button } from "@/components/ui/button";
 import {

--- a/src/components/DateIdeaCard.tsx
+++ b/src/components/DateIdeaCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import { useState } from 'react';
 import { Heart, Share2 } from 'lucide-react';
 import { DateIdeaCardProps } from '@/types';

--- a/src/components/ShareModal.tsx
+++ b/src/components/ShareModal.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import React, { useState } from 'react';
 import { Check, Link, Share2 } from 'lucide-react';
 import {


### PR DESCRIPTION
## Summary
- ensure interactive components are client components

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f56b02bb0832581e6c9755838aef0