### PR TITLE
v0.9.0: implement save/bookmark date ideas with localStorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to DateDash will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.9.0] - 2026-02-08
+
+### Added
+
+- Save/bookmark date ideas with localStorage persistence
+- `useSavedIdeas` custom hook for managing saved state
+- Visual toggle on Heart button: filled red when saved, outline when not
+- Save functionality on shared date idea page
+- `SavedIdeaEntry` and `SavedIdeasStore` types (ready for future MongoDB sync)
+
 ## [0.8.0] - 2026-02-07
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# Project Instructions
+
+## Versioning & Changelog
+
+- **Always update `CHANGELOG.md`** when creating a new version/feature PR
+- **Always bump the version in `package.json`** to match the new changelog entry
+- Use [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) format
+- PR titles for version bumps must be prefixed with `vX.X.X:` (e.g., `v0.9.0: implement save/bookmark`)
+
+## Git Workflow
+
+- Never commit directly to `main` — always use `develop` branch and create a PR
+- One logical change per commit, following Conventional Commits (see global CLAUDE.md)
+- PR title format for releases: `vX.X.X: short description`
+
+## Deployment
+
+- Deployed on Vercel from `main` branch (production) and `develop` branch (preview)
+- Required environment variables: `GOOGLE_API_KEY`, `MONGODB_URI`, `MONGODB_DB`
+- MongoDB Atlas network access must allow `0.0.0.0/0` for Vercel's dynamic IPs

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-dash",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -6,6 +6,7 @@ import { CityCombobox } from '@/components/CityCombobox';
 import { DateIdeaCard } from '@/components/DateIdeaCard';
 import { DateIdea } from '@/types';
 import { Skeleton } from '@/components/ui/skeleton';
+import { useSavedIdeas } from '@/hooks/useSavedIdeas';
 import {
   Carousel,
   CarouselContent,
@@ -19,6 +20,7 @@ export default function Home() {
   const [error, setError] = useState<string | undefined>();
   const [dateIdeas, setDateIdeas] = useState<DateIdea[]>([]);
   const [selectedCity, setSelectedCity] = useState<string>('');
+  const { isSaved, toggleSave } = useSavedIdeas();
 
   const handleCitySelect = async (city: string) => {
     setIsLoading(true);
@@ -93,7 +95,8 @@ export default function Home() {
                       <DateIdeaCard
                         idea={idea}
                         city={selectedCity}
-                        onLove={() => console.log('Loved:', idea.title)}
+                        onLove={() => toggleSave(selectedCity, idea)}
+                        isSaved={isSaved(selectedCity, idea.title)}
                       />
                     </CarouselItem>
                   ))}

--- a/src/app/shared/page.tsx
+++ b/src/app/shared/page.tsx
@@ -8,12 +8,14 @@ import { ArrowLeft } from 'lucide-react';
 import { DateIdea } from '@/types';
 import { DateIdeaCard } from '@/components/DateIdeaCard';
 import { Button } from '@/components/ui/button';
+import { useSavedIdeas } from '@/hooks/useSavedIdeas';
 import { Skeleton } from '@/components/ui/skeleton';
 
 function SharedDateContent() {
   const searchParams = useSearchParams();
   const [sharedIdea, setSharedIdea] = useState<DateIdea | null>(null);
   const [city, setCity] = useState<string>('');
+  const { isSaved, toggleSave } = useSavedIdeas();
 
   useEffect(() => {
     const idea: DateIdea = {
@@ -55,10 +57,11 @@ function SharedDateContent() {
           </p>
         </div>
 
-        <DateIdeaCard 
+        <DateIdeaCard
           idea={sharedIdea}
           city={city}
-          onLove={() => {}}
+          onLove={() => toggleSave(city, sharedIdea)}
+          isSaved={isSaved(city, sharedIdea.title)}
         />
 
         <div className="text-center">

--- a/src/components/DateIdeaCard.tsx
+++ b/src/components/DateIdeaCard.tsx
@@ -4,12 +4,13 @@ import { DateIdeaCardProps } from '@/types';
 import { Card, CardHeader, CardTitle, CardDescription, CardContent, CardFooter } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import ShareModal from '@/components/ShareModal';
+import { cn } from '@/lib/utils';
 
 interface ExtendedDateIdeaCardProps extends DateIdeaCardProps {
   city: string;
 }
 
-export function DateIdeaCard({ idea, onLove, city }: ExtendedDateIdeaCardProps) {
+export function DateIdeaCard({ idea, onLove, city, isSaved = false }: ExtendedDateIdeaCardProps) {
   const [isShareModalOpen, setIsShareModalOpen] = useState(false);
 
   return (
@@ -36,10 +37,16 @@ export function DateIdeaCard({ idea, onLove, city }: ExtendedDateIdeaCardProps) 
             variant="outline"
             size="icon"
             onClick={onLove}
-            className="h-8 w-8 rounded-full border-secondary/30 hover:text-primary hover:border-primary"
+            className={cn(
+              "h-8 w-8 rounded-full border-secondary/30 hover:text-primary hover:border-primary",
+              isSaved && "text-red-500 border-red-500/30 hover:text-red-600 hover:border-red-600"
+            )}
           >
-            <Heart className="h-4 w-4" />
-            <span className="sr-only">Love this idea</span>
+            <Heart className={cn(
+              "h-4 w-4 transition-colors",
+              isSaved && "fill-current text-red-500"
+            )} />
+            <span className="sr-only">{isSaved ? 'Remove from saved' : 'Save this idea'}</span>
           </Button>
           <Button
             variant="outline"

--- a/src/hooks/useSavedIdeas.ts
+++ b/src/hooks/useSavedIdeas.ts
@@ -1,0 +1,66 @@
+'use client';
+
+import { useState, useEffect, useCallback } from 'react';
+import { DateIdea, SavedIdeaEntry, SavedIdeasStore } from '@/types';
+
+const STORAGE_KEY = 'date-dash:saved';
+
+function getSavedKey(city: string, title: string): string {
+  return `${city}::${title}`;
+}
+
+function readStore(): SavedIdeasStore {
+  if (typeof window === 'undefined') return {};
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+function writeStore(store: SavedIdeasStore): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(store));
+  } catch {
+    // localStorage full or unavailable — fail silently
+  }
+}
+
+export function useSavedIdeas() {
+  const [savedIdeas, setSavedIdeas] = useState<SavedIdeasStore>({});
+
+  useEffect(() => {
+    setSavedIdeas(readStore());
+  }, []);
+
+  const isSaved = useCallback(
+    (city: string, title: string): boolean => {
+      return getSavedKey(city, title) in savedIdeas;
+    },
+    [savedIdeas]
+  );
+
+  const toggleSave = useCallback(
+    (city: string, idea: DateIdea): void => {
+      const key = getSavedKey(city, idea.title);
+      const updated = { ...savedIdeas };
+
+      if (key in updated) {
+        delete updated[key];
+      } else {
+        updated[key] = {
+          idea,
+          city,
+          savedAt: new Date().toISOString(),
+        };
+      }
+
+      setSavedIdeas(updated);
+      writeStore(updated);
+    },
+    [savedIdeas]
+  );
+
+  return { savedIdeas, isSaved, toggleSave };
+}

--- a/src/hooks/useSavedIdeas.ts
+++ b/src/hooks/useSavedIdeas.ts
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect, useCallback } from 'react';
-import { DateIdea, SavedIdeaEntry, SavedIdeasStore } from '@/types';
+import { DateIdea, SavedIdeasStore } from '@/types';
 
 const STORAGE_KEY = 'date-dash:saved';
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -20,6 +20,17 @@ export interface DateIdeaCardProps {
   idea: DateIdea;
   onLove?: () => void;
   onShare?: () => void;
+  isSaved?: boolean;
+}
+
+export interface SavedIdeaEntry {
+  idea: DateIdea;
+  city: string;
+  savedAt: string;
+}
+
+export interface SavedIdeasStore {
+  [key: string]: SavedIdeaEntry;
 }
 
 export interface DateIdeasCarouselProps {


### PR DESCRIPTION
## Summary
- Wire up the existing Heart/Love button as a save/bookmark toggle
- Saved ideas persist in localStorage (keyed by `city::title`)
- Filled red heart when saved, outline when not
- Works on both the main page carousel and shared idea page
- Data model is ready for future MongoDB sync when auth is re-enabled

### New files
- `src/hooks/useSavedIdeas.ts` — custom hook for localStorage persistence

### Modified files
- `src/types/index.ts` — added `SavedIdeaEntry`, `SavedIdeasStore`, `isSaved` prop
- `src/app/page.tsx` — wired hook to card rendering
- `src/components/DateIdeaCard.tsx` — visual toggle (filled/outline heart)
- `src/app/shared/page.tsx` — wired hook to shared page

## Test plan
- [ ] Search for a city → click heart on an idea → heart fills red
- [ ] Refresh page → search same city → heart is still filled
- [ ] Click filled heart → unfills (removed from saved)
- [ ] Check devtools → Application → localStorage → `date-dash:saved` key exists
- [ ] Visit a shared idea link → heart button works there too

🤖 Generated with [Claude Code](https://claude.com/claude-code)