### PR TITLE
v0.11.0: rate limiting and input sanitization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Remove saved ideas by clicking the heart icon on the favorites page
 - "My Favorites" navigation link on the home page
 
+### Fixed
+
+- Add rate limiting to `/api/generate` (10 req/hour per IP via MongoDB)
+- Sanitize city input: max 100 chars, Unicode-aware pattern validation, regex escaping to prevent ReDoS
+- Truncate query param on `/api/cities/search` to 100 chars
+
 ## [0.9.0] - 2026-02-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to DateDash will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.11.0] - 2026-02-17
+
+### Added
+
+- Rate limiting on `/api/generate` (10 req/hour per IP via MongoDB with TTL auto-expiry)
+
+### Fixed
+
+- Sanitize city input: max 100 chars, Unicode-aware pattern validation, regex escaping to prevent ReDoS
+- Truncate query param on `/api/cities/search` to 100 chars
+
 ## [0.10.0] - 2026-02-17
 
 ### Added
@@ -13,12 +24,6 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - Empty state with friendly prompt when no favorites exist
 - Remove saved ideas by clicking the heart icon on the favorites page
 - "My Favorites" navigation link on the home page
-
-### Fixed
-
-- Add rate limiting to `/api/generate` (10 req/hour per IP via MongoDB)
-- Sanitize city input: max 100 chars, Unicode-aware pattern validation, regex escaping to prevent ReDoS
-- Truncate query param on `/api/cities/search` to 100 chars
 
 ## [0.9.0] - 2026-02-08
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "date-dash",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/src/app/api/cities/search/route.ts
+++ b/src/app/api/cities/search/route.ts
@@ -1,23 +1,31 @@
 import { NextResponse } from 'next/server';
 import { CITIES } from '@/data/cities';
 
+const QUERY_MAX_LENGTH = 100;
+
 export async function GET(request: Request) {
   try {
     const { searchParams } = new URL(request.url);
-    const query = searchParams.get('q')?.toLowerCase().trim();
+    const raw = searchParams.get('q');
 
-    if (!query) {
+    if (!raw || typeof raw !== 'string') {
+      return NextResponse.json({ cities: [] });
+    }
+
+    const query = raw.toLowerCase().trim().slice(0, QUERY_MAX_LENGTH);
+
+    if (query.length === 0) {
       return NextResponse.json({ cities: [] });
     }
 
     const matches = [];
     for (let i = 0; i < CITIES.length && matches.length < 10; i++) {
       const city = CITIES[i].toLowerCase();
-      
+
       if (city > query && !city.startsWith(query)) {
         break;
       }
-      
+
       if (city.startsWith(query)) {
         matches.push({
           id: matches.length,

--- a/src/app/api/generate/route.ts
+++ b/src/app/api/generate/route.ts
@@ -2,15 +2,37 @@ import { NextResponse } from 'next/server';
 import { GoogleGenerativeAI } from '@google/generative-ai';
 import clientPromise from '@/lib/db/mongodb';
 import { DateIdea, AIResponse, AIDateIdea } from '@/lib/db/types';
+import { checkRateLimit } from '@/lib/rateLimit';
 
 const genAI = new GoogleGenerativeAI(process.env.GOOGLE_API_KEY!);
 
 export const maxDuration = 30;
 
+const CITY_MAX_LENGTH = 100;
+const CITY_PATTERN = /^[\p{L}\p{M}\s\-'.,()\u0600-\u06FF]+$/u;
+
+function escapeRegExp(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 const PROMPT = `Generate 10 unique and creative date ideas for {city}. Format as JSON array with properties: title (max 50 chars), description (max 150 chars), estimatedCost (local and USD e.g. £30-50 ($38-63 USD)), icon (single emoji). Return only valid JSON like: {"ideas":[{"title":"Sample Date","description":"Sample description","estimatedCost":"£30-50 ($38-63 USD)","icon":"🎸"}]}`;
 
 export async function POST(req: Request) {
   try {
+    // --- Rate limiting ---
+    const forwarded = req.headers.get('x-forwarded-for');
+    const ip = forwarded?.split(',')[0]?.trim() || 'unknown';
+    const limit = await checkRateLimit(ip);
+
+    if (!limit.allowed) {
+      const retryAfter = Math.ceil(limit.retryAfterMs / 1000);
+      return NextResponse.json(
+        { success: false, error: 'Too many requests. Please try again later.' },
+        { status: 429, headers: { 'Retry-After': String(retryAfter) } },
+      );
+    }
+
+    // --- Input validation ---
     const { city } = await req.json();
     console.log('[generate] Request for city:', city);
 
@@ -21,18 +43,34 @@ export async function POST(req: Request) {
       );
     }
 
+    const trimmedCity = city.trim();
+
+    if (trimmedCity.length === 0 || trimmedCity.length > CITY_MAX_LENGTH) {
+      return NextResponse.json(
+        { success: false, error: 'City name must be between 1 and 100 characters' },
+        { status: 400 }
+      );
+    }
+
+    if (!CITY_PATTERN.test(trimmedCity)) {
+      return NextResponse.json(
+        { success: false, error: 'City name contains invalid characters' },
+        { status: 400 }
+      );
+    }
+
     console.log('[generate] Connecting to MongoDB...');
-    console.log('[generate] MONGODB_URI set:', !!process.env.MONGODB_URI);
-    console.log('[generate] MONGODB_DB set:', !!process.env.MONGODB_DB);
     const client = await clientPromise;
     console.log('[generate] MongoDB connected');
 
     const db = client.db(process.env.MONGODB_DB);
     const dateIdeas = db.collection<DateIdea>('dateIdeas');
 
+    // Escape special regex chars to prevent ReDoS
+    const escapedCity = escapeRegExp(trimmedCity);
     console.log('[generate] Querying for existing ideas...');
     const existingIdeas = await dateIdeas
-      .find({ city: { $regex: new RegExp('^' + city + '$', 'i') } })
+      .find({ city: { $regex: new RegExp('^' + escapedCity + '$', 'i') } })
       .toArray();
     console.log('[generate] Found', existingIdeas.length, 'existing ideas');
 
@@ -41,10 +79,9 @@ export async function POST(req: Request) {
     }
 
     console.log('[generate] No cached ideas, calling Gemini API...');
-    console.log('[generate] GOOGLE_API_KEY set:', !!process.env.GOOGLE_API_KEY);
     const model = genAI.getGenerativeModel({ model: "gemini-2.5-flash-lite" });
 
-    const result = await model.generateContent(PROMPT.replace('{city}', city));
+    const result = await model.generateContent(PROMPT.replace('{city}', trimmedCity));
     console.log('[generate] Gemini API responded');
     const response = result.response.text();
     console.log('[generate] Response text length:', response?.length);
@@ -72,7 +109,7 @@ export async function POST(req: Request) {
     console.log('[generate] Parsed', parsedResponse.ideas.length, 'ideas, saving to MongoDB...');
     const newIdeas: DateIdea[] = parsedResponse.ideas.map((idea: AIDateIdea) => ({
       ...idea,
-      city,
+      city: trimmedCity,
       likeCount: 0,
       createdAt: new Date()
     }));

--- a/src/lib/rateLimit.ts
+++ b/src/lib/rateLimit.ts
@@ -1,0 +1,70 @@
+import clientPromise from '@/lib/db/mongodb';
+
+const WINDOW_MS = 60 * 60 * 1000; // 1 hour
+const MAX_REQUESTS = 10;
+
+interface RateLimitEntry {
+  ip: string;
+  timestamps: Date[];
+  expiresAt: Date;
+}
+
+/**
+ * Check whether the given IP has exceeded the rate limit.
+ * Uses MongoDB so the limit is shared across all Vercel instances.
+ *
+ * Returns { allowed, remaining, retryAfterMs }.
+ */
+export async function checkRateLimit(ip: string) {
+  const client = await clientPromise;
+  const db = client.db(process.env.MONGODB_DB);
+  const col = db.collection<RateLimitEntry>('rateLimits');
+
+  // Ensure TTL index exists (MongoDB will auto-delete expired docs).
+  // createIndex is a no-op when the index already exists.
+  await col.createIndex({ expiresAt: 1 }, { expireAfterSeconds: 0 });
+
+  const now = new Date();
+  const windowStart = new Date(now.getTime() - WINDOW_MS);
+
+  // Atomically prune old timestamps and push the new one
+  const result = await col.findOneAndUpdate(
+    { ip },
+    {
+      $pull: { timestamps: { $lt: windowStart } } as never,
+      $setOnInsert: { ip },
+      $set: { expiresAt: new Date(now.getTime() + WINDOW_MS) },
+    },
+    { upsert: true, returnDocument: 'after' }
+  );
+
+  const doc = result;
+  const currentCount = doc?.timestamps?.length ?? 0;
+
+  if (currentCount >= MAX_REQUESTS) {
+    // Find the oldest timestamp in the window to calculate retry-after
+    const oldest = doc!.timestamps[0];
+    const retryAfterMs = oldest.getTime() + WINDOW_MS - now.getTime();
+    return {
+      allowed: false,
+      remaining: 0,
+      retryAfterMs: Math.max(retryAfterMs, 0),
+    };
+  }
+
+  // Under the limit — record this request
+  await col.updateOne(
+    { ip },
+    {
+      $push: { timestamps: now },
+      $set: { expiresAt: new Date(now.getTime() + WINDOW_MS) },
+    },
+    { upsert: true },
+  );
+
+  return {
+    allowed: true,
+    remaining: MAX_REQUESTS - currentCount - 1,
+    retryAfterMs: 0,
+  };
+}


### PR DESCRIPTION
## Summary
- Rate limiting on `/api/generate` — 10 requests/hour per IP via MongoDB with TTL auto-expiry, works across Vercel's distributed serverless instances
- Input sanitization on `/api/generate` — city name length (max 100), Unicode-aware character pattern validation, regex special char escaping to prevent ReDoS
- Input sanitization on `/api/cities/search` — query param truncated to 100 chars

## Test plan
- [ ] Send 11 rapid POST requests to `/api/generate` — verify the 11th returns 429 with `Retry-After` header
- [ ] Send a city name with regex special chars (e.g. `New York.*`) — verify 400 rejection
- [ ] Send a city name over 100 chars — verify 400 rejection
- [ ] Send a normal city name — verify ideas still generate correctly
- [ ] Send a city search query >100 chars to `/api/cities/search` — verify it's truncated without error
- [ ] Verify Vercel preview deployment builds and runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)